### PR TITLE
fix case strong or emphasis in link

### DIFF
--- a/src/util/extractText.ts
+++ b/src/util/extractText.ts
@@ -1,4 +1,5 @@
 import { PhrasingContent } from 'mdast'
+import parseText from './parseText'
 
 type content = {
   text: string
@@ -9,29 +10,13 @@ const extractText = (
   contents: PhrasingContent[],
   blankSpaceReplaceText = '-'
 ): content => {
-  const link = {
+  let link = {
     text: '',
     href: '#',
   }
 
   contents.forEach((content) => {
-    switch (content.type) {
-      case 'text':
-      case 'inlineCode': {
-        const text = content.value
-        link.text += text
-        link.href += text.replace(/\s+/g, blankSpaceReplaceText)
-        break
-      }
-      case 'link':
-      case 'strong':
-      case 'emphasis': {
-        const text = content.children[0]?.value as string
-        link.text += text || ''
-        link.href += text?.replace(/\s+/g, blankSpaceReplaceText) || ''
-        break
-      }
-    }
+    link = parseText(content, link, blankSpaceReplaceText)
   })
 
   return link

--- a/src/util/parseText.ts
+++ b/src/util/parseText.ts
@@ -1,0 +1,31 @@
+import { PhrasingContent } from 'mdast'
+
+type content = {
+  text: string
+  href: string
+}
+
+const parseText = (
+  content: PhrasingContent,
+  link: content,
+  blankSpaceReplaceText = '-'
+): content => {
+  switch (content?.type) {
+    case 'text':
+    case 'inlineCode': {
+      const text = content.value
+      link.text += text
+      link.href += text.replace(/\s+/g, blankSpaceReplaceText)
+      break
+    }
+    case 'link':
+    case 'strong':
+    case 'emphasis': {
+      return parseText(content.children[0], link, blankSpaceReplaceText)
+    }
+  }
+
+  return link
+}
+
+export default parseText

--- a/test/util/extractText.test.ts
+++ b/test/util/extractText.test.ts
@@ -128,4 +128,34 @@ describe('extractText', () => {
     expect(content.text).toEqual('emphasis')
     expect(content.href).toEqual('#emphasis')
   })
+
+  test('strong and emphasis', () => {
+    const markdown = '# **strong** *emphasis*'
+    const headingList = markdownToHeadingList(markdown)
+
+    const item = headingList[0]
+    const content = extractText(item.children)
+    expect(content.text).toEqual('strong emphasis')
+    expect(content.href).toEqual('#strong-emphasis')
+  })
+
+  test('emphasis in link', () => {
+    const markdown = '# [*emphasis*](example.com)'
+    const headingList = markdownToHeadingList(markdown)
+
+    const item = headingList[0]
+    const content = extractText(item.children)
+    expect(content.text).toEqual('emphasis')
+    expect(content.href).toEqual('#emphasis')
+  })
+
+  test('strong in link', () => {
+    const markdown = '# [**strong**](example.com)'
+    const headingList = markdownToHeadingList(markdown)
+
+    const item = headingList[0]
+    const content = extractText(item.children)
+    expect(content.text).toEqual('strong')
+    expect(content.href).toEqual('#strong')
+  })
 })

--- a/test/util/parseText.test.ts
+++ b/test/util/parseText.test.ts
@@ -1,0 +1,85 @@
+import markdownToAst from '../../src/util/markdownToAst'
+import pickHeadingFromAst from '../../src/util/pickHeadingFromAst'
+import parseHeadingAST from '../../src/util/parseHeadingAST'
+import parseText from '../../src/util/parseText'
+
+let link = {
+  text: '',
+  href: '#',
+}
+
+describe('extractText', () => {
+  function markdownToHeadingList(markdown: string) {
+    const headingAst = pickHeadingFromAst(markdownToAst(markdown))
+    return parseHeadingAST(headingAst)
+  }
+
+  function initLink() {
+    link = {
+      text: '',
+      href: '#',
+    }
+  }
+
+  beforeEach(() => initLink())
+
+  test('text equales hyperlink text', () => {
+    const markdown = '# h1'
+    const headingList = markdownToHeadingList(markdown)
+
+    const phrasingContents = headingList[0].children
+    phrasingContents.forEach((content) => {
+      link = parseText(content, link)
+    })
+
+    expect(link.text).toEqual('h1')
+    expect(link.href).toEqual('#h1')
+  })
+
+  test('set blankSpaceReplaceText', () => {
+    const markdown = '# h 1'
+    const headingList = markdownToHeadingList(markdown)
+
+    const phrasingContents = headingList[0].children
+    phrasingContents.forEach((content) => {
+      link = parseText(content, link, '_')
+    })
+    expect(link.text).toEqual('h 1')
+    expect(link.href).toEqual('#h_1')
+  })
+  test('emphasis', () => {
+    const markdown = '# *emphasis*'
+    const headingList = markdownToHeadingList(markdown)
+
+    const phrasingContents = headingList[0].children
+    phrasingContents.forEach((content) => {
+      link = parseText(content, link)
+    })
+    expect(link.text).toEqual('emphasis')
+    expect(link.href).toEqual('#emphasis')
+  })
+
+  test('strong and emphasis', () => {
+    const markdown = '# **strong** *emphasis*'
+    const headingList = markdownToHeadingList(markdown)
+
+    const phrasingContents = headingList[0].children
+    phrasingContents.forEach((content) => {
+      link = parseText(content, link)
+    })
+    expect(link.text).toEqual('strong emphasis')
+    expect(link.href).toEqual('#strong-emphasis')
+  })
+
+  test('emphasis in link', () => {
+    const markdown = '# [*emphasis*](example.com)'
+    const headingList = markdownToHeadingList(markdown)
+
+    const phrasingContents = headingList[0].children
+    phrasingContents.forEach((content) => {
+      link = parseText(content, link)
+    })
+    expect(link.text).toEqual('emphasis')
+    expect(link.href).toEqual('#emphasis')
+  })
+})


### PR DESCRIPTION
```markdown
# [**strong**](example.com)
```
second heading

| | expected |
|--|--|
| depth | 1 |
| text | strong |
| href | #strong |
